### PR TITLE
flush output on print

### DIFF
--- a/src/Logging.jl
+++ b/src/Logging.jl
@@ -43,6 +43,7 @@ for (fn,lvl,clr) in ((:debug,    DEBUG,    :cyan),
                 Base.print_with_color($(Expr(:quote, clr)), logger.output, logstring )
             else
                 print(logger.output, logstring)
+                flush(logger.output)
             end
         end
     end


### PR DESCRIPTION
I'm pretty sure this is how the Python logging generally behaves. And it's the way I like it.
