### PR TITLE
Fix Logger("mylogger")

### DIFF
--- a/src/Logging.jl
+++ b/src/Logging.jl
@@ -86,7 +86,7 @@ show(io::IO, logger::Logger) = print(io, "Logger(", join([logger.name,
                                                           logger.parent.name], ","), ")")
 
 const _root = Logger("root", WARNING, STDERR)
-Logger(name::AbstractString;args...) = configure(Logger(name, WARNING, [STDERR], _root); args...)
+Logger(name::AbstractString;args...) = configure(Logger(name, WARNING, STDERR, _root); args...)
 Logger() = Logger("logger")
 
 write_log(syslog::SysLog, color::Symbol, msg::AbstractString) = send(syslog.socket, syslog.ip, syslog.port, length(msg) > syslog.maxlength ? msg[1:syslog.maxlength] : msg)

--- a/test/test_hierarchy.jl
+++ b/test/test_hierarchy.jl
@@ -1,0 +1,17 @@
+module TestHierarchy
+
+using Base.Test
+using Logging
+
+# configre root logger
+Logging.configure(level=DEBUG)
+root = Logging._root
+
+
+loggerA = Logger("loggerA")
+
+# test hierarchy
+@test root.parent == root
+@test loggerA.parent == root
+
+end


### PR DESCRIPTION
Logger("mylogger") triggers an error due to `[STDERR]` is not `Array{LogOutput, 1}`, but a `Array{IO, 1}`