### PR TITLE
Fix deprecation warning on julia v0.5

### DIFF
--- a/src/Logging.jl
+++ b/src/Logging.jl
@@ -61,9 +61,9 @@ type Logger
     Logger{T<:LogOutput}(name::AbstractString, level::LogLevel, output::Array{T,1}) = (x = new(); x.name = name; x.level=level; x.output=output; x.parent=x)
 end
 
-show(io::IO, logger::Logger) = print(io, "Logger(", join([logger.name,
-                                                          logger.level,
-                                                          logger.output,
+show(io::IO, logger::Logger) = print(io, "Logger(", join([logger.name;
+                                                          logger.level;
+                                                          logger.output;
                                                           logger.parent.name], ","), ")")
 
 const _root = Logger("root", WARNING, STDERR)


### PR DESCRIPTION
This fixes the following waring:

```jl
julia> Logging.configure(level=ERROR)
WARNING: [a,b,...] concatenation is deprecated; use [a;b;...] instead
```