### PR TITLE
RFC: Unexport logging functions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ os:
   - linux
   - osx
 julia:
-  - 0.4
+  - 0.5
   - nightly
 notifications:
   email: false

--- a/README.md
+++ b/README.md
@@ -20,11 +20,11 @@ using Logging
 # Logging.configure(level=WARNING)
 
 function log_test()
-    debug("debug message")
-    info("info message")
-    warn("warning message")
-    err("error message")
-    critical("critical message")
+    Logging.debug("debug message")
+    Logging.info("info message")
+    Logging.warn("warning message")
+    Logging.err("error message")
+    Logging.critical("critical message")
 end
 
 println("Setting level=DEBUG")
@@ -235,44 +235,5 @@ julia> mum_logger = Logger("Mum");
 julia> Logging.configure(mum_logger, level=INFO);
 julia> son_logger = Logger("Son", parent=mum_logger);
 julia> son_logger.level
-INFO
-```
-
-Notes
------
-* By default, `Logging.info` masks `Base.info`.  However, if `Base.info` is called before
-  `using Logging`, `info` will always refer to the `Base` version.
-
-  ```julia
-julia> info("Here's some info.")
-INFO: Here's some info.
-
-julia> using Logging
-Warning: using Logging.info in module Main conflicts with an existing identifier.
-
-julia> @Logging.configure(level=Logging.INFO)
-Logger(root,INFO,TTY(open, 0 bytes waiting),root)
-
-julia> info("Still using Base.info")
-INFO: Still using Base.info
-
-julia> Logging.info("You can still fully qualify Logging.info.")
-17-Jan 13:19:56:INFO:root:You can still fully qualify Logging.info.
-```
-
-  If this is not desirable, you may call `@Logging.configure` with `override_info=true`:
-
-  ```julia
-julia> info("Here's some info again.")
-INFO: Here's some info again.
-
-julia> using Logging
-Warning: using Logging.info in module Main conflicts with an existing identifier.
-
-julia> @Logging.configure(level=Logging.INFO, override_info=true)
-Warning: Method definition info(AbstractString...,) in module Base at util.jl:216 overwritten in module Main at /Users/kevin/.julia/v0.4/Logging/src/Logging.jl:85.
-Logger(root,INFO,TTY(open, 0 bytes waiting),root)
-
-julia> info("Now we're using Logging.info")
-17-Jan 13:17:20:INFO:root:Now we're using Logging.info
+INFO::Logging.LogLevel = 6
 ```

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,1 +1,1 @@
-julia 0.4
+julia 0.5

--- a/src/Logging.jl
+++ b/src/Logging.jl
@@ -116,6 +116,8 @@ for (fn,lvl,clr) in ((:debug,    DEBUG,    :cyan),
 
 end
 
+@deprecate err Logging.error
+
 function configure(logger=_root; args...)
     for (tag, val) in args
         if tag == :parent

--- a/src/Logging.jl
+++ b/src/Logging.jl
@@ -2,11 +2,7 @@ __precompile__()
 
 module Logging
 
-import Base: show, info, warn
-
-export debug, info, warn, err, critical, log,
-       @debug, @info, @warn, @err, @error, @critical,
-       Logger,
+export Logger,
        LogLevel, DEBUG, INFO, WARNING, ERROR, CRITICAL, OFF,
        LogFacility,
        SysLog
@@ -72,10 +68,10 @@ type Logger
     Logger{T<:LogOutput}(name::AbstractString, level::LogLevel, output::Array{T,1}) = (x = new(); x.name = name; x.level=level; x.output=output; x.parent=x)
 end
 
-show(io::IO, logger::Logger) = print(io, "Logger(", join(Any[logger.name,
-                                                             logger.level,
-                                                             logger.output,
-                                                             logger.parent.name], ","), ")")
+Base.show(io::IO, logger::Logger) = print(io, "Logger(", join(Any[logger.name,
+                                                                  logger.level,
+                                                                  logger.output,
+                                                                  logger.parent.name], ","), ")")
 
 const _root = Logger("root", WARNING, STDERR)
 Logger(name::AbstractString;args...) = configure(Logger(name, WARNING, STDERR, _root); args...)
@@ -101,7 +97,7 @@ end
 for (fn,lvl,clr) in ((:debug,    DEBUG,    :cyan),
                      (:info,     INFO,     :blue),
                      (:warn,     WARNING,  :magenta),
-                     (:err,      ERROR,    :red),
+                     (:error,    ERROR,    :red),
                      (:critical, CRITICAL, :red))
 
     @eval function $fn(logger::Logger, msg...)
@@ -113,12 +109,11 @@ for (fn,lvl,clr) in ((:debug,    DEBUG,    :cyan),
     end
 
     @eval $fn(msg...) = $fn(_root, msg...)
-
 end
 
 @deprecate err Logging.error
 
-function configure(logger=_root; args...)
+function _configure(logger=_root; args...)
     for (tag, val) in args
         if tag == :parent
             logger.parent = parent = val::Logger
@@ -136,26 +131,108 @@ function configure(logger=_root; args...)
         tag == :level         ? (logger.level  = val::LogLevel) :
         tag == :override_info ? nothing :  # handled below
         tag == :parent        ? nothing :  # handled above
-                                (Base.error("Logging: unknown configure argument \"$tag\""))
+                                (throw(ArgumentError("Logging: unknown configure argument \"$tag\"")))
     end
 
     logger
 end
 
-override_info(;args...) = (:override_info, true) in args
+"""
+Module which contains versions of the logging functions which
+print a deprecation warning when used.
+
+This is useful for transitioning users to either call the qualified
+function names (e.g., `Logging.info`, `Logging.warn`, etc.) or explicitly
+import the functions.
+"""
+module _Deprecated
+
+import Logging
+
+deprecation_printed = false
+
+for fn in (:debug, :info, :warn, :error, :critical)
+    @eval function $fn(args...)
+        global deprecation_printed
+        if !deprecation_printed
+            Base.warn("""
+                In the future, `using Logging` will not import the following
+                logging functions:
+
+                    debug
+                    info
+                    warn
+                    error
+                    critical
+
+                You can either use these functions by qualifying them
+                (e.g., `Logging.debug(...)`, `Logging.warn(...)`, etc.),
+                or by explicitly importing them:
+
+                    using Logging
+                    import Logging: debug, info, warn, error, critical
+
+                """)
+            deprecation_printed = true
+        end
+
+        Logging.$fn(args...)
+    end
+end
+
+end # module _Deprecated
+
+function _imported_with_using()
+    return all(isdefined.(names(Logging)))
+end
+
+function _logging_funcs_imported()
+    # isdefined "reifies" any object that is defined, making it impossible
+    # it to override it via import.  Therefore, we don't check
+    # `info`, `warn`, and `error`, since these functions exist in
+    # Base and won't be overridden if we check them here.
+    return all(isdefined.([:debug, #=:info, :warn, :error,=# :critical]))
+end
+
+let _macros_loaded = false
+    global macros_loaded, set_macros_loaded
+    macros_loaded() = _macros_loaded
+    set_macros_loaded() = (_macros_loaded = true)
+end
+
+_src_dir = dirname(@__FILE__)
 
 macro configure(args...)
-    _args = gensym()
     quote
-        logger = Logging.configure($(args...))
-        if Logging.override_info($(args...))
-            function Base.info(msg::AbstractString...)
-                Logging.info(Logging._root, msg...)
+        logger = Logging._configure($(args...))
+
+        if Logging._imported_with_using() && !Logging._logging_funcs_imported()
+            # We assume that the user has not manually
+            # imported the Logging functions, and we import
+            # versions of these which print a deprecation warning
+            try
+                import Logging._Deprecated: info, warn, debug, error, critical
+            catch
+                Base.warn("Please call Logging.@configure from the top level (module) scope.")
             end
         end
-        include(joinpath(Pkg.dir("Logging"), "src", "logging_macros.jl"))
+
+        if !Logging.macros_loaded()
+            include(joinpath(Logging._src_dir, "logging_macros.jl"))
+            Logging.set_macros_loaded()
+        end
         logger
     end
+end
+
+function configure(args...; kwargs...)
+    throw(ErrorException("""
+        The functional form of Logging.configure(...) is no longer supported.
+        Instead, call
+
+            Logging.@configure(...)
+
+        """))
 end
 
 end # module

--- a/test/log_test.jl
+++ b/test/log_test.jl
@@ -6,11 +6,11 @@ using Logging
 
 function log_test()
     println("\nTesting function calls:\n")
-    debug("debug message")
-    info("info message")
-    warn("warning message")
-    err("error message")
-    critical("critical message")
+    Logging.debug("debug message")
+    Logging.info("info message")
+    Logging.warn("warning message")
+    Logging.err("error message")
+    Logging.critical("critical message")
 end
 
 function log_test2()
@@ -50,4 +50,3 @@ println("\nSetting level=CRITICAL")
 Logging.configure(level=CRITICAL)
 log_test()
 log_test2()
-

--- a/test/macro_test.jl
+++ b/test/macro_test.jl
@@ -3,7 +3,7 @@ using Base.Test
 
 function test_log_macro_common(flags)
     for (macroname, isshown) in flags
-        ex = Expr(:macrocall, symbol(macroname), "test message")
+        ex = Expr(:macrocall, Symbol(macroname), "test message")
         if isshown
             @test ex |> macroexpand != :nothing
         else
@@ -12,26 +12,50 @@ function test_log_macro_common(flags)
     end
 end
 
+module TestDebug
+using Logging
+import ..test_log_macro_common
 @Logging.configure(level=DEBUG)
 test_log_macro_common([(:@debug, true), (:@info, true), (:@warn, true),
     (:@err, true), (:@critical, true)])
+end
 
+module TestInfo
+using Logging
+import ..test_log_macro_common
 @Logging.configure(level=INFO)
 test_log_macro_common([(:@debug, false), (:@info, true), (:@warn, true),
     (:@err, true), (:@critical, true)])
+end
 
+module TestWarning
+using Logging
+import ..test_log_macro_common
 @Logging.configure(level=WARNING)
 test_log_macro_common([(:@debug, false), (:@info, false), (:@warn, true),
     (:@err, true), (:@critical, true)])
+end
 
+module TestError
+using Logging
+import ..test_log_macro_common
 @Logging.configure(level=ERROR)
 test_log_macro_common([(:@debug, false), (:@info, false), (:@warn, false),
     (:@err, true), (:@critical, true)])
+end
 
+module TestCritical
+using Logging
+import ..test_log_macro_common
 @Logging.configure(level=CRITICAL)
 test_log_macro_common([(:@debug, false), (:@info, false), (:@warn, false),
     (:@err, false), (:@critical, true)])
+end
 
+module TestOff
+using Logging
+import ..test_log_macro_common
 @Logging.configure(level=OFF)
 test_log_macro_common([(:@debug, false), (:@info, false), (:@warn, false),
     (:@err, false), (:@critical, false)])
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,3 @@
-using Logging: debug, info, warn
 include("log_test.jl")
 include("macro_test.jl")
 include("test_hierarchy.jl")


### PR DESCRIPTION
* Two of the logging functions (`info` and `warn`) conflict with
  functions in base, and `error` was originally named `err` for the same
  reason.  Unexporting them removes these conflicts.


* With this change, the functions will (eventually) have to be qualified.

    ```julia
using Logging
Logging.@configure(level=DEBUG)

Logging.debug("Debug message")
Logging.info("Information for you!")
Logging.warn("This is a warning.")
Logging.error("You did something wrong!")
Logging.critical("Danger Will Robinson!")
```
  A user can still call these directly without qualification (and without override warnings) with
    ```julia
using Logging
import Logging: debug, info, warn, error, critical
Logging.@configure(level=DEBUG)

debug("Debug message")
info("Information for you!")
warn("This is a warning.")
error("You did something wrong!")
critical("Danger Will Robinson!")
```
* Also deprecate `Logging.err` in favor of `Logging.error`.  This wasn't possible before because of conflicts with `Base.error`

* In order to properly deprecate the non-qualified version, the `Logging.configure` function was also removed in favor of `Logging.@configure`, and the unqualified names are imported (with a deprecation warning) when the user calls `Logging.@configure`, but only if 1) `Logging` was included with `using Logging`, and 2) the user hasn't already imported the names manually.  (This required a few shenanigans, and might be brittle, but should work most of the time and should only be temporary--e.g., until Julia v0.6).

Looking for comments.  My plan would be to release this as v0.5 only.

Cc: @sbchisholm @aviks @DanielArndt @joshday @Iostanlen @JoshChristie @fiatflux @zxteloiv 
