### PR TITLE
Stop exporting the log function

### DIFF
--- a/src/Logging.jl
+++ b/src/Logging.jl
@@ -4,8 +4,8 @@ module Logging
 
 import Base: show, info, warn
 
-export debug, info, warn, err, critical, log,
-       @debug, @info, @warn, @err, @error, @critical,
+export debug, info, warn, err, critical,
+       @debug, @info, @warn, @err, @error, @critical, @log,
        Logger,
        LogLevel, DEBUG, INFO, WARNING, ERROR, CRITICAL, OFF,
        LogFacility,


### PR DESCRIPTION
`log` has been exported on master for a while, but only in a tagged release for a few days.
This broke http://pkg.julialang.org/logs/RobustLeastSquares_0.4.log (ref: https://github.com/JuliaLang/METADATA.jl/pull/6671#issuecomment-252950989)

