### PR TITLE
Attempt to fix Julia v0.6 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ os:
 julia:
   - 0.4
   - 0.5
+  - 0.6
   - nightly
 notifications:
   email: false

--- a/src/Logging.jl
+++ b/src/Logging.jl
@@ -2,6 +2,7 @@ __precompile__()
 
 module Logging
 
+using Compat: @static
 import Base: show, info, warn
 
 export debug, info, warn, err, critical,
@@ -144,9 +145,12 @@ override_info(;args...) = (:override_info, true) in args
 
 # Keyword arguments x=1 passed to macros are parsed as Expr(:(=), :x, 1) but
 # must be passed as Expr(:(kw), :x, 1) in Julia v0.6. 
-const kwarg_head = VERSION < v"0.6-" ? :(=) : :(kw)
-fix_kwarg(x::Symbol) = x
-fix_kwarg(e::Expr) = e.head == :(=) ? Expr(kwarg_head, e.args...) : e
+@static if VERSION < v"0.6-"
+    fix_kwarg(x) = x
+else
+    fix_kwarg(x::Symbol) = x
+    fix_kwarg(e::Expr) = e.head == :(=) ? Expr(:(kw), e.args...) : e
+end
 
 macro configure(args...)
     _args = gensym()

--- a/src/Logging.jl
+++ b/src/Logging.jl
@@ -155,8 +155,8 @@ end
 macro configure(args...)
     _args = gensym()
     quote
-        logger = Logging.configure($([esc(fix_kwarg(a)) for a in args]...))
-        if Logging.override_info($([esc(fix_kwarg(a)) for a in args]...))
+        logger = Logging.configure($([fix_kwarg(a) for a in args]...))
+        if Logging.override_info($([fix_kwarg(a) for a in args]...))
             function Base.info(msg::AbstractString...)
                 Logging.info(Logging._root, msg...)
             end

--- a/src/Logging.jl
+++ b/src/Logging.jl
@@ -146,7 +146,7 @@ override_info(;args...) = (:override_info, true) in args
 # must be passed as Expr(:(kw), :x, 1) in Julia v0.6. 
 const kwarg_head = VERSION < v"0.6-" ? :(=) : :(kw)
 fix_kwarg(x::Symbol) = x
-fix_kwarg(e::Expr) = e.head == :(=) ? Expr(:(kw), e.args...) : e
+fix_kwarg(e::Expr) = e.head == :(=) ? Expr(kwarg_head, e.args...) : e
 
 macro configure(args...)
     _args = gensym()

--- a/src/logging_macros.jl
+++ b/src/logging_macros.jl
@@ -17,7 +17,7 @@ for (mac,fn,lvl) in ((:debug,    :(Logging.debug),    Logging.DEBUG),
         if $lvl > level
             esc(:nothing)
         else
-            Expr(:call, $fn, msg...)
+            Expr(:call, $fn, [esc(m) for m in msg]...)
         end
     end
 

--- a/src/logging_macros.jl
+++ b/src/logging_macros.jl
@@ -15,7 +15,7 @@ for (mac,fn,lvl) in ((:debug,    :(Logging.debug),    Logging.DEBUG),
         end
 
         if $lvl > level
-            :nothing
+            esc(:nothing)
         else
             Expr(:call, $fn, msg...)
         end

--- a/test/macro_scope_test.jl
+++ b/test/macro_scope_test.jl
@@ -3,8 +3,16 @@
 module InnerModule
 
 import Logging
+@Logging.configure(level=DEBUG)
+
 using Compat
 using Base.Test
+
+function test_non_global_interpolation(y)
+    @info("y = $y")
+end
+
+test_non_global_interpolation(5)
 
 function test_log_macro_common(flags)
     for (macroname, isshown) in flags
@@ -17,7 +25,6 @@ function test_log_macro_common(flags)
     end
 end
 
-@Logging.configure(level=DEBUG)
 test_log_macro_common([(:@debug, true), (:@info, true), (:@warn, true),
     (:@err, true), (:@critical, true)])
 

--- a/test/macro_scope_test.jl
+++ b/test/macro_scope_test.jl
@@ -1,0 +1,44 @@
+# Ensure that Logging.jl works when loaded with `import` rather than `using`
+# since `import` does not bring constants like `DEBUG` into scope:
+module InnerModule
+
+import Logging
+using Compat
+using Base.Test
+
+function test_log_macro_common(flags)
+    for (macroname, isshown) in flags
+        ex = Expr(:macrocall, Symbol(macroname), "test message")
+        if isshown
+            @test ex |> macroexpand != :nothing
+        else
+            @test ex |> macroexpand == :nothing
+        end
+    end
+end
+
+@Logging.configure(level=DEBUG)
+test_log_macro_common([(:@debug, true), (:@info, true), (:@warn, true),
+    (:@err, true), (:@critical, true)])
+
+@Logging.configure(level=INFO)
+test_log_macro_common([(:@debug, false), (:@info, true), (:@warn, true),
+    (:@err, true), (:@critical, true)])
+
+@Logging.configure(level=WARNING)
+test_log_macro_common([(:@debug, false), (:@info, false), (:@warn, true),
+    (:@err, true), (:@critical, true)])
+
+@Logging.configure(level=ERROR)
+test_log_macro_common([(:@debug, false), (:@info, false), (:@warn, false),
+    (:@err, true), (:@critical, true)])
+
+@Logging.configure(level=CRITICAL)
+test_log_macro_common([(:@debug, false), (:@info, false), (:@warn, false),
+    (:@err, false), (:@critical, true)])
+
+@Logging.configure(level=OFF)
+test_log_macro_common([(:@debug, false), (:@info, false), (:@warn, false),
+    (:@err, false), (:@critical, false)])
+
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,3 +2,4 @@ using Logging: debug, info, warn
 include("log_test.jl")
 include("macro_test.jl")
 include("test_hierarchy.jl")
+include("macro_scope_test.jl")


### PR DESCRIPTION
There were some changes to the way keyword arguments are parsed in Julia v0.6 that broke Logging.jl. I believe this should fix it, but I'd appreciate it if someone familiar with how the package works could try it as well (the unit tests are passing, but I don't know the expected behavior well). 